### PR TITLE
Improve SQL markup in READMEs

### DIFF
--- a/Week1/LESSONPLAN.md
+++ b/Week1/LESSONPLAN.md
@@ -238,25 +238,25 @@ CREATE TABLE employees (
 The following command inserts a row in the table `employees`.
 Note that the sequence of columns must be followed.
 
-```
+```sql
 INSERT INTO employees VALUES (101, "Dan", 5000, "2019-06-24", 'm');
 ```
 
 The following command uses column name (also known as field name sometimes) syntax:
 
-```
+```sql
 INSERT INTO employees (employee_name , salary, employee_id, gender, joining_date) VALUES("Dany", 5000, 102, 'f', "2019-05-20");
 ```
 
 The following command uses the same syntax to add multiple rows at a time
 
-```
+```sql
 INSERT INTO employees (employee_name , salary, employee_id, gender, joining_date) VALUES("Ben", 7000, 103, 'm', "2019-07-20"), ("Benta", 3000, 104, 'f', "2019-10-12"), ("Raj", 9000, 105, 'm', "2019-01-01");
 ```
 
 The following command uses the SET syntax to insert values in a random order of columns:
 
-```
+```sql
 INSERT INTO employees SET employee_name = "Joe", salary = 4000, joining_date = "2019-07-01", gender = 'f', employee_id = 100;
 ```
 
@@ -267,7 +267,7 @@ INSERT INTO employees SET employee_name = "Joe", salary = 4000, joining_date = "
 
 The following command displays the entire table. The `*` means all columns.
 
-```
+```sql
 SELECT * FROM employees;
 ```
 
@@ -277,7 +277,7 @@ The condition is applied on the column `salary` of each row.
 `SELECT employee_name` will only print the `employee_name` column of the rows
 where `salary` column has the value `>3000`.
 
-```
+```sql
 SELECT employee_name from employees
 WHERE salary > 3000;
 ```
@@ -288,7 +288,7 @@ The following command updates the salary of the employee whose `employee_id` is 
 Note that `=` works as an assignment operator in `SET salary = 8000`
 but works as a comparison operator in the WHERE clause `employee_id = 102`.
 
-```
+```sql
 UPDATE employees
 SET salary = 8000
 WHERE employee_id = 102;
@@ -298,7 +298,7 @@ WHERE employee_id = 102;
 
 The following command deletes all (rows of) employees who joined after the 1st of July 2019.
 
-```
+```sql
 DELETE from employees
 WHERE joining_date > "2019-07-01";
 ```
@@ -341,7 +341,7 @@ the columns as `NOT NULL` so that MySQL can do optimizations in storing/indexing
 
 Demonstrate the difference with the live execution of the following sequence of commands:
 
-```
+```sql
 CREATE TABLE default_not_null_demo(num1 int, num2 int NOT NULL, num3 int default 5555, num4 int not null default 1111);
 DESCRIBE default_not_null_demo;
 INSERT INTO default_not_null_demo set num2 = 1, num4 = default;
@@ -361,7 +361,7 @@ can hold numbers greater than 999.
 
 Illustrate the difference with the live execution of the following sequence of commands:
 
-```
+```sql
 CREATE TABLE test_int(num1 int(4) ZEROFILL, num2 int(6));
 INSERT INTO test_int values (23,34);
 INSERT INTO test_int values (3,534);
@@ -385,7 +385,7 @@ may be a suitable data type for `last login` where the exact time and time zone 
 
 Demonstrate with the live execution of the following sequence of commands:
 
-```
+```sql
 CREATE TABLE test_timestamp (dt datetime, ts timestamp);
 
 INSERT INTO test_timestamp VALUES ("2020-01-01 00:00:00", "2020-01-01 00:00:00");

--- a/Week2/LESSONPLAN.md
+++ b/Week2/LESSONPLAN.md
@@ -71,49 +71,42 @@ Add a select query to that program using await and promisify.
 Consider the following commands (# represents comments).
 
 ```sql
-#
-create table with two columns.one with primary key and one with unique key constraint
+-- create table with two columns: one with primary key and one with unique key constraint
 CREATE TABLE pri_uniq_demo
 (
     id_pr int PRIMARY KEY,
     id_un int UNIQUE
 );
 
-#
-Note the error that says that the primary key column cannot be NULL
+-- Note the error that says that the primary key column cannot be NULL
 INSERT INTO pri_uniq_demo VALUES (NULL, NULL);
-#ERROR
-1048 (23000): Column 'id_pr' cannot be null
+ERROR 1048 (23000): Column 'id_pr' cannot be null
 
-# Note that the UNIQUE key column can be NULL
+-- Note that the UNIQUE key column can be NULL
 INSERT INTO pri_uniq_demo VALUES (1, NULL);
-#Query
-OK, 1 row affected (0.00 sec)
+Query OK, 1 row affected (0.00 sec)
 
-# Normal insertion
+-- Normal insertion
 INSERT INTO pri_uniq_demo VALUES (2, 2);
-#Query
-OK, 1 row affected (0.05 sec)
+Query OK, 1 row affected (0.05 sec)
 
-# Note that you cannot insert 2 in the id_un column because it should be UNIQUE
+-- Note that you cannot insert 2 in the id_un column because it should be UNIQUE
 INSERT INTO pri_uniq_demo VALUES (3, 2);
-#ERROR
-1062 (23000): Duplicate entry '2' for key 'id_un'
+ERROR 1062 (23000): Duplicate entry '2' for key 'id_un'
 
-# Note that you cannot insert 2 in the id_pr column because it is PRIMARY KEY
+-- Note that you cannot insert 2 in the id_pr column because it is PRIMARY KEY
 INSERT INTO pri_uniq_demo VALUES (2, 3);
-#ERROR
-1062 (23000): Duplicate entry '2' for key 'PRIMARY'
+ERROR 1062 (23000): Duplicate entry '2' for key 'PRIMARY'
 
 ```
 
 #### Exercise
 
-```
-# Find out type T and Constraint C for each column.
+```sql
+-- Find out type T and Constraint C for each column.
 CREATE TABLE Airline_passengers(ticket_numer T C, passenger_name T C, date_of_birth T C, passport_number T C);
 
-Hint: A very young baby may not need a ticket!
+-- Hint: A very young baby may not need a ticket!
 ```
 
 #### Essence
@@ -155,39 +148,33 @@ dept_id column of the departments table in which it works as the primary key.**
 #### Example
 
 ```sql
-#
-Add the column dept_id to the employees table
+-- Add the column dept_id to the employees table
 ALTER TABLE employees
     ADD COLUMN dept_id int;
 
-#
-Add the constraint foreign key
+-- Add the constraint foreign key
 ALTER TABLE employees
     ADD CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments (dept_id);
 
-#
-Add some sample rows in the departments table
+-- Add some sample rows in the departments table
  INSERT INTO departments VALUES (5001, "Sales");
 INSERT INTO departments
 VALUES (5002, "Development");
 INSERT INTO departments
 VALUES (5003, "Marketing");
 
-#
-Try updating the dept_id of an employee with an existing department
+-- Try updating the dept_id of an employee with an existing department
 UPDATE employees
 SET dept_id = 5001
 where employee_id = 101;
 
-#
-Try updating the dept_id of an employee with a department that does not exist
+-- Try updating the dept_id of an employee with a department that does not exist
 UPDATE employees
 SET dept_id = 9999
 where employee_id = 101;
 
-#
-Example of 1-1 relationship
-# Creating table Account with the same primary key as the Employees table
+-- Example of 1-1 relationship
+-- Creating table Account with the same primary key as the Employees table
 CREATE TABLE Account
 (
     employee_id int,
@@ -234,9 +221,7 @@ key is called as the **Composite Key**
 #### Example
 
 ```sql
-#
-create
-projects table
+-- create projects table
 CREATE TABLE projects
 (
     proj_id    int,
@@ -244,17 +229,14 @@ CREATE TABLE projects
     start_date datetime
 );
 
-#
-Insert sample values
+-- Insert sample values
 INSERT INTO projects VALUES(9001, "Jazz", "2018-01-01");
 INSERT INTO projects
 VALUES (9002, "Mellow", "2019-03-01");
 INSERT INTO projects
 VALUES (9003, "Classical", "2020-01-01");
 
-#
-create
-emp_proj relationship table with composite primary key
+-- create emp_proj relationship table with composite primary key
 CREATE TABLE emp_proj
 (
     emp_id  int,
@@ -298,10 +280,9 @@ clause.
 #### Example
 
 ```sql
-#We
-must join the tables `employees` and `departments` and then choose the relevant rows.
+-- We must join the tables `employees` and `departments` and then choose the relevant rows.
 
-# INNER JOIN
+-- INNER JOIN
 SELECT
     employee_name
 FROM employees as E
@@ -310,8 +291,7 @@ FROM employees as E
      ON E.dept_id = D.dept_id
 WHERE D.dept_name = "Sales";
 
-#
-Comma (,) or CROSS join
+-- Comma (,) or CROSS join
 SELECT
     employee_name
 FROM employees as E,
@@ -355,7 +335,7 @@ for self join, we must use **aliases** so that disambiguation of column names ca
 #### Example
 
 ```sql
-When we want to print employees and their reporting mangagers.
+-- When we want to print employees and their reporting mangagers.
 SELECT E1.employee_name as Employee, E2. employee_name as Manager
 FROM employees as E1
 INNER JOIN
@@ -366,9 +346,7 @@ ON E1.reports_to = E2.employee_id
 #### Exercise
 
 ```sql
-#
-Add the city column,
-update records in the employees table
+-- Add the city column, update records in the employees table
 ALTER TABLE employees
     add column city varchar(50);
 UPDATE employees
@@ -633,33 +611,32 @@ that describes indexes concisely.
 First we will create a table with a large number of records.
 The full program can be found in `Week2/generate_big_table.js`, but here is the snippet
 
-```
+```js
 async function seedDatabase() {
-
-    const CREATE_TABLE = `
+  const CREATE_TABLE = `
         CREATE TABLE IF NOT EXISTS big
         (
             id_pk INT PRIMARY KEY AUTO_INCREMENT,
             number   INT
         );`;
 
-    execQuery(CREATE_TABLE);
-    let rows = []
-    for (i = 1; i <= 1000000; i++) {
-        rows.push([i]);
-        if(i%10000 === 0){
-            console.log("i="+i);
-            await execQuery('INSERT INTO big(number) VALUES ?',[rows]);
-            rows = [];
-        }
+  execQuery(CREATE_TABLE);
+  let rows = [];
+  for (i = 1; i <= 1000000; i++) {
+    rows.push([i]);
+    if (i % 10000 === 0) {
+      console.log("i=" + i);
+      await execQuery("INSERT INTO big(number) VALUES ?", [rows]);
+      rows = [];
     }
+  }
 }
 ```
 
 The following two queries will show the difference (in execution time) between using the index and not using the index
 when we retrieve the data.
 
-```
+```sql
 mysql> SELECT * FROM big WHERE id_pk = 1000;
 +-------+--------+
 | id_pk | number |
@@ -680,7 +657,7 @@ mysql> SELECT * FROM big WHERE number = 1000;
 The first query's result is instant because the `WHERE` clause uses the `id_pk` column which is a primary key.
 Note that for a primary key column, MySQL automatically creates an index. This can be confirmed with the following query
 
-```
+```sql
 mysql> SHOW indexes from big;
 +-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+
 | Table | Non_unique | Key_name | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type |
@@ -697,7 +674,7 @@ go in the `big` table and search row by row to check which row contains the valu
 The `describe` command shows how many rows are accessed to fetch the result of the query.
 Check the `rows` column in the output of the following queries.
 
-```
+```sql
 mysql> DESCRIBE SELECT * FROM big WHERE number = 1000;
 +----+-------------+-------+------------+------+---------------+------+---------+------+----------+----------+-------------+
 | id | select_type | table | partitions | type | possible_keys | key  | key_len | ref  | rows     | filtered | Extra       |
@@ -716,13 +693,13 @@ mysql> DESCRIBE SELECT * FROM big WHERE id_pk = 1000;
 
 We can now create an index on the `number` column as follows:
 
-```
+```sql
 CREATE INDEX idx_number ON big(number);
 ```
 
 Now we can re-run the select query which will be faster:
 
-```
+```sql
 mysql> SELECT * FROM big WHERE number = 1000;
 +-------+--------+
 | id_pk | number |
@@ -746,7 +723,7 @@ Rows matched: 1000000  Changed: 1000000  Warnings: 0
 
 Now, let us remove the index
 
-```
+```sql
 mysql> DROP INDEX idx_number ON big;
 Query OK, 0 rows affected (1.59 sec)
 Records: 0  Duplicates: 0  Warnings: 0
@@ -754,7 +731,7 @@ Records: 0  Duplicates: 0  Warnings: 0
 
 and re-run the update query.
 
-```
+```sql
 mysql> UPDATE big SET number = number + 100000;
 Query OK, 1000000 rows affected (6.14 sec)
 Rows matched: 1000000  Changed: 1000000  Warnings: 0
@@ -767,7 +744,7 @@ We can see that without the index, update of the number column is much faster (6
 Create a composite index using columns (`employee_name and salary`) on the `employees` table and check the query
 performance of following queries
 
-```
+```sql
 DESCRIBE SELECT * FROM employees WHERE employee_name = 'John' and salary = 50000
 DESCRIBE SELECT * FROM employees WHERE employee_name = 'John'
 DESCRIBE SELECT * FROM employees WHERE salary = 50000

--- a/Week3/LESSONPLAN.md
+++ b/Week3/LESSONPLAN.md
@@ -106,7 +106,7 @@ this [Functional Dependency Wikipage](https://en.wikipedia.org/wiki/Functional_d
 
 Consider the following table
 
-```
+```sql
 +-------------+------------+-----------------------+
 | Employee Id |   Name     |   Contact             |
 +-------------+------------+-----------------------+
@@ -124,7 +124,7 @@ numeric values (for phone numbers) and string value (for emails).
 
 This table could be converted to 1NF as follows:
 
-```
+```sql
 +-------------+------------+------------------------+
 | Employee Id |   Name     | Phone      | Email     |
 +-------------+------------+------------------------+
@@ -145,7 +145,7 @@ In real life, you actually need to
 
 Consider the following table (employee-project M-M relationship table).
 
-```
+```sql
 +-------------+------------+-----------------------+
 | Employee Id | Project ID |  Project Budget       |
 +-------------+------------+-----------------------+
@@ -172,7 +172,7 @@ adding it to the project table.
 
 Consider the following table (employees)
 
-```
+```sql
 +-------------+------------+-----------------------+
 | Employee Id | Dept Id    |  Dept Location        |
 +-------------+------------+-----------------------+
@@ -191,7 +191,7 @@ This table violates the 3NF because there is a transitive dependency.
 
 Consider the following table (students opting for subjects)
 
-```
+```sql
 +-------------+------------+-----------------------+
 | Student Id  | Subject    |  Professor            |
 +-------------+------------+-----------------------+
@@ -210,7 +210,7 @@ This table violates the 3.5NF because there is a functional dependency
 
 This table could be converted to 3.5NF as follows:
 
-```
+```sql
 +-------------+------------+
 | Student Id  | Prof Id    |
 +-------------+------------+
@@ -225,7 +225,7 @@ This table could be converted to 3.5NF as follows:
 
 and
 
-```
+```sql
 +-------------+------------+----------+
 | Prof Id     | Professor  |  Subject |
 +-------------+------------+----------+
@@ -238,7 +238,7 @@ and
 
 Consider the following table (students opting for subjects)
 
-```
+```sql
 +-------------+------------+-----------+
 | Student     | Subject    |  Hobby    |
 +-------------+------------+-----------+
@@ -254,7 +254,7 @@ This table violates 4NF because `Subject` and `Hobby` are independent of each ot
 Hence the hobby of the student must be repeated in the table with each subject
 the student chooses.
 
-```
+```sql
 +-------------+------------+-----------------------+
 | Student     | Subject    |  Hobby                |
 +-------------+------------+-----------------------+
@@ -273,7 +273,7 @@ the student chooses.
 It leads to a lot of repetition.
 This table could be converted to 4NF by splitting it into two.
 
-```
+```sql
 +-------------+------------+
 | Student     | Subject    |
 +-------------+------------+
@@ -287,7 +287,7 @@ This table could be converted to 4NF by splitting it into two.
 
 and
 
-```
+```sql
 +-------------+-----------+
 | Student     |  Hobby    |
 +-------------+-----------+
@@ -303,7 +303,7 @@ and
 
 Normalize the following table.
 
-```
+```sql
 +-------------+------------+-----------------------------------------------+------------+
 | Full name   | Adddress   |  Movies rented                                | Salutation |
 +-------------+------------+-----------------------------------------------+------------+
@@ -337,7 +337,7 @@ one of them, then there is inconsistency.
 
 Transactions have the following syntax:
 
-```
+```sql
 start transaction;
 SQL command 1
 SQL command 2 ...
@@ -345,8 +345,8 @@ SQL command N
 
 rollback OR commit;
 
-# "rollback" aborts the transaction (also ends the transaction)
-# "commit" commits the transaction (also ends the transaction)
+-- "rollback" aborts the transaction (also ends the transaction)
+-- "commit" commits the transaction (also ends the transaction)
 ```
 
 > Note that there is no "end transaction" command. To end the transaction,
@@ -371,7 +371,7 @@ Atomicity can be demonstrated with the following `rollback` and `commit` example
 
 #### Rollback example
 
-```
+```sql
 set autocommit = 0; # default is 1 which automatically commits every command as transaction.
 
 start transaction;
@@ -391,7 +391,7 @@ select * from employees; # Show the old salary
 
 #### Commit example
 
-```
+```sql
 set autocommit = 0; # default is 1 which automatically commits every command as transaction.
 
 start transaction;
@@ -413,8 +413,8 @@ select * from employees; # Show the new salary
 
 Start two `mysql` command line clients.
 
-```
-# First client
+```sql
+--- First client
 
 update employees set city = 'Mumbai' where employee_id = 101;
 
@@ -423,8 +423,8 @@ commit;
 
 In the second client, show that the value is updated.
 
-```
-# Second client
+```sql
+--- Second client
 select * from employees;
 
 ```
@@ -432,8 +432,8 @@ select * from employees;
 > The change made by one database client in the database server will be seen by the other client(s). Thus,
 > both clients have the consistent view on the database.
 
-```
-# First client
+```sql
+--- First client
 
 set autocommit = 1;
 
@@ -443,8 +443,8 @@ update employees set salary = 7000 where employee_id = 101;
 
 ```
 
-```
-# Second client
+```sql
+-- Second client
 
 select * from employees; # Will hang because First client has the WRITE lock on that table
 ```
@@ -478,14 +478,14 @@ Use the `prompt` package in `input-demo.js` to simulate the input from HTML form
 
 `sql-injection.js` contains three ways of passing the input to the select query
 
-```
+```js
 // 1. Naive way of passing the parameter to the query
-const select_query = `select * from employees WHERE employee_id =  ${input_number};`
+const select_query = `select * from employees WHERE employee_id =  ${input_number};`;
 ```
 
 This way is vulnerable to the following attacks.
 
-```
+```bash
 $ node sql-injection.js # Execute the Javascript program from the (VS code) terminal.
 
 prompt: employee_number: 1234 OR 1=1
@@ -502,12 +502,14 @@ prompt: employee_number: 1234 OR 1=1; drop table demo;
 
 To solve this problem, there are two ways of sanitizing the input:
 
-```
+```js
 // 1. Escaping the parameter ( replacing the unwanted characters)
-const select_query = `select * from employees WHERE employee_id =` + connection.escape(input_number);
+const select_query =
+  `select * from employees WHERE employee_id =` +
+  connection.escape(input_number);
 
 // 2. Using a question mark syntax to do the escaping
-const select_query = `select * from employees WHERE employee_id = ?`
+const select_query = `select * from employees WHERE employee_id = ?`;
 ```
 
 ### Exercise


### PR DESCRIPTION
Some of the examples in the lesson plans don't display the SQL markup properly, especially when using the markup preview in VSCode. This commit adds the sql tag on any sql markup and uses SQL-style comments 